### PR TITLE
DOC: add note to readme about submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ This is mostly to help me quickstart a presentation, but hopefully it might be u
 
 Combine `./export.sh` with [entr](https://github.com/eradman/entr) to autorebuild the file on save and [live-reload](https://github.com/blaise-io/live-reload/) to refresh your browser when the index.html file changes and you have a live-preview.
 
+## Setup
+
+1. use template button
+2. clone new repo locally
+3. remember to also checkout the submodules
+4. edit talk.org
+
+
 ## Multiplex
 
 You can make multiplex work by following these steps:


### PR DESCRIPTION
I almost added a note about using `python -m http.serve` to get a local server, but I suspect you have a better way.